### PR TITLE
Fix tasks not showing on initial load

### DIFF
--- a/kanban-project/js/app.js
+++ b/kanban-project/js/app.js
@@ -1714,21 +1714,27 @@ function deleteTask(taskId) {
 
     // --- 12. 应用初始化 ---
     function initApp() {
-        document.addEventListener('DOMContentLoaded', () => {
+        const startApp = () => {
             loadThemeFromStorage();
             loadTasksFromStorage();
             addEventListeners();
             renderBoard();
             renderLabelFilters();
-            
+
             // 初始化视图
             const savedView = loadViewFromStorage();
             setView(savedView, true); // 初始加载，无动画
-            
+
             // 初始化提醒功能
             updateActiveReminders();
             requestNotificationPermission();
-        });
+        };
+
+        if (document.readyState === 'loading') {
+            document.addEventListener('DOMContentLoaded', startApp);
+        } else {
+            startApp();
+        }
     }
 
     // 启动应用


### PR DESCRIPTION
## Summary
- handle DOMContentLoaded correctly in `initApp` to ensure tasks load immediately

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6842ab6fd680832d9c95743ead6d2d1c