### PR TITLE
修复导入导出事件监听器重复注册的问题

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -2023,9 +2023,6 @@ function deleteTask(taskId) {
         addImportExportListeners();
     }
 
-    // 初始化导入导出功能
-    addImportExportListeners();
-
     // --- 暴露必要的函数到全局作用域，供键盘快捷键模块使用 ---
     window.openModal = openModal;
     window.deleteTask = deleteTask;


### PR DESCRIPTION
## 摘要
- 避免在 DOM 完成后重复注册导入导出事件监听器

## 测试
- `node --check js/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aac6bc5114832dab0b97aad10f3d6a